### PR TITLE
Fixes and examples

### DIFF
--- a/examples/proximity-and-light.py
+++ b/examples/proximity-and-light.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import time
 import ltr559

--- a/examples/proximity-and-light.py
+++ b/examples/proximity-and-light.py
@@ -1,17 +1,15 @@
 #!/bin/env python
 
-from ltr559 import setup, update_sensor, get_lux, get_proximity
+import time
+import ltr559
 
-if __name__ == "__main__":
-    setup()
-    try:
-        while True:
-            update_sensor()
-            lux = get_lux()
-            prox = get_proximity()
+try:
+    while True:
+        lux = ltr559.get_lux()
+        prox = ltr559.get_proximity()
 
-            print("Lux: {:06.2f}, Proximity: {:04d}".format(lux, prox))
+        print("Lux: {:06.2f}, Proximity: {:04d}".format(lux, prox))
 
-            time.sleep(0.05)
-    except KeyboardInterrupt:
-        pass
+        time.sleep(0.05)
+except KeyboardInterrupt:
+    pass

--- a/library/ltr559/__init__.py
+++ b/library/ltr559/__init__.py
@@ -241,9 +241,23 @@ def setup():
         ALS_CONTROL.write()
 
     with _ltr559.PS_CONTROL as PS_CONTROL:
-        PS_CONTROL.set_active(1)
+        PS_CONTROL.set_active(True)
         PS_CONTROL.set_saturation_indicator_enable(1)
         PS_CONTROL.write()
+
+    _ltr559.PS_MEAS_RATE.set_rate_ms(100)
+    _ltr559.ALS_MEAS_RATE.set_integration_time_ms(50)
+    _ltr559.ALS_MEAS_RATE.set_repeat_rate_ms(50)
+
+    with _ltr559.ALS_THRESHOLD as ALS_THRESHOLD:
+        ALS_THRESHOLD.set_lower(0x0000)
+        ALS_THRESHOLD.set_upper(0xFFFF)
+        ALS_THRESHOLD.write()
+
+    with _ltr559.PS_THRESHOLD as PS_THRESHOLD:
+        PS_THRESHOLD.set_lower(0b0000)
+        PS_THRESHOLD.set_upper(0xFFFF)
+        PS_THRESHOLD.write()
 
     _ltr559.PS_OFFSET.set_offset(0)
 

--- a/library/test.py
+++ b/library/test.py
@@ -1,16 +1,16 @@
 import time
 import ltr559 as l
 
-assert l.PART_ID.get_part_number() == 0x09
-assert l.PART_ID.get_revision() == 0x02
+assert l._ltr559.PART_ID.get_part_number() == 0x09
+assert l._ltr559.PART_ID.get_revision() == 0x02
 
 print("""
 Found LTR-559.
 Part ID: 0x{:02x}
 Revision: 0x{:02x}
 """.format(
-    l.PART_ID.get_part_number(),
-    l.PART_ID.get_revision())
+    l._ltr559.PART_ID.get_part_number(),
+    l._ltr559.PART_ID.get_revision())
 )
 
 print("""


### PR DESCRIPTION
Refactors `proximity-and-light.py` into a proper example and adds missing imports.

Sets default integration times, thresholds and repeat rates for light sensor.