### PR TITLE
Fixed interrupt support and example for #6

### DIFF
--- a/examples/proximity-interrupt.py
+++ b/examples/proximity-interrupt.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import ltr559
+import signal
+import RPi.GPIO as GPIO
+import time
+
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(4, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+ltr559.set_proximity_threshold(0, 1000)
+
+# Tricky, since this value is *NOT* lux
+# ltr559.set_light_threshold(20, 0xffff)
+
+def interrupt_handler(pin):
+    int_als, int_ps = ltr559.get_interrupt()
+    if int_ps:
+        print("Proximity interrupt: {}".format(ltr559.get_proximity()))
+    # if int_als:
+    #    print("Light sensor interrupt: {}".format(ltr559.get_lux()))
+
+GPIO.add_event_detect(4, callback=interrupt_handler, edge=GPIO.FALLING)
+
+signal.pause()
+

--- a/examples/proximity-interrupt.py
+++ b/examples/proximity-interrupt.py
@@ -2,7 +2,6 @@
 import ltr559
 import signal
 import RPi.GPIO as GPIO
-import time
 
 print("""proximity-interrupt.py - Watch the LTR559 interrupt pin and trigger a function on change.
 
@@ -37,6 +36,7 @@ ltr559.set_proximity_threshold(0, 1000)
 # Tricky, since this value is *NOT* lux
 # ltr559.set_light_threshold(20, 0xffff)
 
+
 # This handler function is called by `add_event_detect` when a falling edge is detected on the INTERRUPT_PIN
 def interrupt_handler(pin):
     int_als, int_ps = ltr559.get_interrupt()
@@ -44,6 +44,7 @@ def interrupt_handler(pin):
         print("Proximity interrupt: {}".format(ltr559.get_proximity()))
     # if int_als:
     #    print("Light sensor interrupt: {}".format(ltr559.get_lux()))
+
 
 # Watch the INTERRUPT_PIN for a falling edge (HIGH/LOW transition)
 GPIO.add_event_detect(INTERRUPT_PIN, callback=interrupt_handler, edge=GPIO.FALLING)

--- a/examples/proximity-interrupt.py
+++ b/examples/proximity-interrupt.py
@@ -8,6 +8,8 @@ print("""proximity-interrupt.py - Watch the LTR559 interrupt pin and trigger a f
 
 This script enables the LTR559's interrupt pin and sets up RPi.GPIO to watch it for changes.
 
+Tap the LTR559 to trigger the interrupt.
+
 Press Ctrl+C to exit!
 
 """)

--- a/examples/proximity-interrupt.py
+++ b/examples/proximity-interrupt.py
@@ -4,14 +4,38 @@ import signal
 import RPi.GPIO as GPIO
 import time
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(4, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+print("""proximity-interrupt.py - Watch the LTR559 interrupt pin and trigger a function on change.
 
+This script enables the LTR559's interrupt pin and sets up RPi.GPIO to watch it for changes.
+
+Press Ctrl+C to exit!
+
+""")
+
+# Breakout garden uses BCM4 as a shared interrupt pin
+INTERRUPT_PIN = 4
+
+# Tell RPi.GPIO we'll be working with BCM pin numbering
+GPIO.setmode(GPIO.BCM)
+
+# Below we're setting up the LTR559 INTERRUPT_PIN in active LOW mode
+# This means it should be pulled "UP", which keeps it HIGH via a weak resistor
+# and when the LTR559 asserts the interrupt pin it will pull i=t LOW giving
+# us a "falling edge" transition to watch for.
+GPIO.setup(INTERRUPT_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+# Enable interrupts and set the pin to active LOW mode
+# This *must* be called before any other method on LTR559,
+# otherwise `setup` will be called automatically for you.
+ltr559.setup(enable_interrupts=True, interrupt_pin_polarity=0)
+
+# Set the threshold outside which an interrupt will be triggered
 ltr559.set_proximity_threshold(0, 1000)
 
 # Tricky, since this value is *NOT* lux
 # ltr559.set_light_threshold(20, 0xffff)
 
+# This handler function is called by `add_event_detect` when a falling edge is detected on the INTERRUPT_PIN
 def interrupt_handler(pin):
     int_als, int_ps = ltr559.get_interrupt()
     if int_ps:
@@ -19,7 +43,8 @@ def interrupt_handler(pin):
     # if int_als:
     #    print("Light sensor interrupt: {}".format(ltr559.get_lux()))
 
-GPIO.add_event_detect(4, callback=interrupt_handler, edge=GPIO.FALLING)
+# Watch the INTERRUPT_PIN for a falling edge (HIGH/LOW transition)
+GPIO.add_event_detect(INTERRUPT_PIN, callback=interrupt_handler, edge=GPIO.FALLING)
 
+# Prevent out Python script from exiting abruptly
 signal.pause()
-

--- a/library/ltr559/__init__.py
+++ b/library/ltr559/__init__.py
@@ -205,7 +205,7 @@ def get_revision():
     return _ltr559.PART_ID.get_revision()
 
 
-def setup():
+def setup(enable_interrupts=False, interrupt_pin_polarity=1):
     """Set up the LTR559 sensor"""
     global _is_setup
     if _is_setup:
@@ -229,10 +229,11 @@ def setup():
     except KeyboardInterrupt:
         pass
 
-    with _ltr559.INTERRUPT as INTERRUPT:
-        INTERRUPT.set_mode('als+ps')
-        INTERRUPT.set_polarity(0)
-        INTERRUPT.write()
+    if enable_interrupts:
+        with _ltr559.INTERRUPT as INTERRUPT:
+            INTERRUPT.set_mode('als+ps')
+            INTERRUPT.set_polarity(interrupt_pin_polarity=interrupt_pin_polarity)
+            INTERRUPT.write()
 
     with _ltr559.PS_LED as PS_LED:
         PS_LED.set_current_ma(50)

--- a/library/ltr559/__init__.py
+++ b/library/ltr559/__init__.py
@@ -19,18 +19,18 @@ _ch1_c = (-11059, 19548, -1185, 0)
 class Bit12Adapter(Adapter):
     def _encode(self, value):
         """
-        Convert the 16-bit output into the correct format for reading:
-
-            0bLLLLLLLLXXXXHHHH -> 0bHHHHLLLLLLLL
-        """
-        return ((value & 0xFF)) << 8 | ((value & 0xF00) >> 8)
-
-    def _decode(self, value):
-        """
         Convert the 12-bit input into the correct format for the registers,
         the low byte followed by 4 empty bits and the high nibble:
 
             0bHHHHLLLLLLLL -> 0bLLLLLLLLXXXXHHHH
+        """
+        return ((value & 0xFF) << 8) | ((value & 0xF00) >> 8)
+
+    def _decode(self, value):
+        """
+        Convert the 16-bit output into the correct format for reading:
+
+            0bLLLLLLLLXXXXHHHH -> 0bHHHHLLLLLLLL
         """
         return ((value & 0xFF00) >> 8) | ((value & 0x000F) << 8)
 
@@ -161,8 +161,8 @@ _ltr559 = Device(I2C_ADDR, bit_width=8, registers=(
     )),
 
     Register('PS_THRESHOLD', 0x90, fields=(
-        BitField('upper', 0xFF0F0000, adapter=Bit12Adapter(), bit_width=16),
-        BitField('lower', 0x0000FF0F, adapter=Bit12Adapter(), bit_width=16)
+        BitField('upper', 0xFF0F0000, adapter=Bit12Adapter()),
+        BitField('lower', 0x0000FF0F, adapter=Bit12Adapter())
     ), bit_width=32),
 
     # PS_OFFSET defines the measurement offset value to correct for proximity
@@ -229,6 +229,11 @@ def setup():
     except KeyboardInterrupt:
         pass
 
+    with _ltr559.INTERRUPT as INTERRUPT:
+        INTERRUPT.set_mode('als+ps')
+        INTERRUPT.set_polarity(0)
+        INTERRUPT.write()
+
     with _ltr559.PS_LED as PS_LED:
         PS_LED.set_current_ma(50)
         PS_LED.set_duty_cycle(1.0)
@@ -263,8 +268,6 @@ def setup():
 
     _ltr559.PS_OFFSET.set_offset(0)
 
-    _ltr559.INTERRUPT.set_mode('als+ps')
-
 
 def set_light_threshold(lower, upper):
     """Set light interrupt threshold
@@ -291,6 +294,7 @@ def set_proximity_threshold(lower, upper):
     with _ltr559.PS_THRESHOLD as PS_THRESHOLD:
         PS_THRESHOLD.set_lower(lower)
         PS_THRESHOLD.set_upper(upper)
+        PS_THRESHOLD.write()
 
 
 def set_proximity_rate_ms(rate_ms):
@@ -449,6 +453,15 @@ def get_lux():
     """Return the ambient light value in lux"""
     update_sensor()
     return _lux
+
+
+def get_interrupt():
+    """Return the light and proximity sensor interrupt status"""
+    setup()
+    with _ltr559.ALS_PS_STATUS as ALS_PS_STATUS:
+        ps_int = ALS_PS_STATUS.get_ps_interrupt()
+        als_int = ALS_PS_STATUS.get_als_interrupt()
+    return als_int, ps_int
 
 
 def get_proximity():

--- a/library/ltr559/__init__.py
+++ b/library/ltr559/__init__.py
@@ -232,7 +232,7 @@ def setup(enable_interrupts=False, interrupt_pin_polarity=1):
     if enable_interrupts:
         with _ltr559.INTERRUPT as INTERRUPT:
             INTERRUPT.set_mode('als+ps')
-            INTERRUPT.set_polarity(interrupt_pin_polarity=interrupt_pin_polarity)
+            INTERRUPT.set_polarity(interrupt_pin_polarity)
             INTERRUPT.write()
 
     with _ltr559.PS_LED as PS_LED:


### PR DESCRIPTION
This fix enables interrupts - which must be done prior to enabling the sensor components.

Before merging, interrupts should be disabled by default and possible to enable with a manual call to `setup()`.